### PR TITLE
Remove Batch from Shell group

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -267,7 +267,6 @@ Awk:
 
 Batchfile:
   type: programming
-  group: Shell
   search_term: bat
   aliases:
   - bat


### PR DESCRIPTION
This pull request removes Batch from the Shell group as discussed in #1483.